### PR TITLE
Adapted get_first_name to be explicit about what gender value required

### DIFF
--- a/names/__init__.py
+++ b/names/__init__.py
@@ -30,8 +30,10 @@ def get_name(filename):
 
 
 def get_first_name(gender=None):
-    if gender not in ('male', 'female'):
+    if gender is None:
         gender = random.choice(('male', 'female'))
+    if gender not in ('male', 'female'):
+        raise ValueError("Only 'male' and 'female' are supported as gender")
     return get_name(FILES['first:%s' % gender]).capitalize()
 
 

--- a/test_names.py
+++ b/test_names.py
@@ -87,6 +87,10 @@ class NamesTest(unittest.TestCase):
             self.assertEqual(names.get_first_name(gender='male'), "")
             self.assertEqual(names.get_first_name(gender='female'), "")
             self.assertEqual(names.get_last_name(), "")
+    
+    def test_only_male_and_female_gender_are_supported(self):
+        with self.assertRaises(ValueError):
+            names.get_first_name(gender='other')
 
 
 class CommandLineTest(unittest.TestCase):


### PR DESCRIPTION
It seems wrong that `names.get_first_name(gender="other")` now randomly selects a `"male"` or `"female"` gender value without telling the developer. Given the discussions about gender in tech I think it's better to be explicit about passing in `"male"` or `"female"` and only selecting a random value when `gender` equals `None`.

To view this differently: as there currently are only male and female lists of names, it's better to let those who use the `names` package decide rather than letting the `names` package accept seemingly arbitrary gender values.
