### PR TITLE
Removed sudo from installation command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Installation
 
 The script is `available on PyPI`_.  To install with pip::
 
-    sudo pip install names
+    pip install names
 
 
 Usage


### PR DESCRIPTION
Recommending installation via sudo should not be done as use of virtualenv is preferred. Given the popularity of virtualenv for isolating dependencies (which is now also part of Python 3), it makes sense to only recommend installation with regular permissions, not sudo. This library should be installed as one of the other isolated dependencies of a project and as such it shouldn't be installed as a global dependency (only in rare cases).
