### PR TITLE
Implement bulk generation module

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Authors
 
 - Trey Hunner <http://treyhunner.com>
 - Simeon Visser <http://simeonvisser.com>
+- Austin Roberts <http://ausiv.com>

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,37 @@ Here are examples of all current features:
     >>> names.get_last_name()
     'Szczepanek'
 
+Bulk Name Generation
+~~~~~~~~~~~~~~~~~~~~
+If you're generating a large volume of names, the bulk names module will be more
+memory intensive, but faster. To use this module, simply replace:
+
+.. code-block:: pycon
+
+    >>> import names
+
+with
+
+.. code-block:: pycon
+
+    >>> import names.bulk as names
+
+and it will cache all of the names into memory, instead of going to the files
+for each lookup. For example:
+
+.. code-block:: pycon
+
+    >>> import names.bulk as names
+    >>> names.get_full_name()
+    u'Patricia Halford'
+    >>> names.get_full_name(gender='male')
+    u'Patrick Keating'
+    >>> names.get_first_name()
+    'Bernard'
+    >>> names.get_first_name(gender='female')
+    'Christina'
+    >>> names.get_last_name()
+    'Szczepanek'
 
 License
 -------

--- a/names/bulk.py
+++ b/names/bulk.py
@@ -1,0 +1,73 @@
+from __future__ import unicode_literals
+from os.path import abspath, join, dirname
+import random
+import sys
+
+
+__title__ = 'names'
+__version__ = '0.3.0.post1'
+__author__ = 'Austin Roberts'
+__license__ = 'MIT'
+
+
+full_path = lambda filename: abspath(join(dirname(__file__), filename))
+
+
+FILES = {
+    'first:male': full_path('dist.male.first'),
+    'first:female': full_path('dist.female.first'),
+    'last': full_path('dist.all.last'),
+}
+
+cache = {}
+
+def load_file(filename):
+    try:
+        return cache[filename]
+    except KeyError:
+        cache[filename] = []
+        with open(filename) as fd:
+            for line in fd:
+                name, _, cummulative, _ = line.split()
+                cache[filename].append((name, float(cummulative)))
+        return cache[filename]
+
+
+def get_name(filename):
+    # Do a binary search to pick a name
+    selected = random.random() * 90
+    names = load_file(filename)
+    max_index = len(names)
+    min_index = 0
+    if min_index == max_index:
+        # Empty file
+        return ""
+    while min_index < max_index:
+        index = (min_index + max_index) / 2
+        name, cummulative = names[index]
+        if cummulative < selected:
+            min_index = index
+        else:
+            max_index = index
+        if max_index == min_index + 1:
+            # Once the min_index and max_index are one apart, we need to look at
+            # them directly
+            if names[min_index][1] > selected:
+                return names[min_index][0]
+            return names[max_index][0]
+    return name
+
+def get_first_name(gender=None):
+    if gender is None:
+        gender = random.choice(('male', 'female'))
+    if gender not in ('male', 'female'):
+        raise ValueError("Only 'male' and 'female' are supported as gender")
+    return get_name(FILES['first:%s' % gender]).capitalize()
+
+
+def get_last_name():
+    return get_name(FILES['last']).capitalize()
+
+
+def get_full_name(gender=None):
+    return "{0} {1}".format(get_first_name(gender), get_last_name())

--- a/names/bulk.py
+++ b/names/bulk.py
@@ -43,7 +43,7 @@ def get_name(filename):
         # Empty file
         return ""
     while min_index < max_index:
-        index = (min_index + max_index) / 2
+        index = (min_index + max_index) // 2
         name, cummulative = names[index]
         if cummulative < selected:
             min_index = index

--- a/names/bulk.py
+++ b/names/bulk.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from os.path import abspath, join, dirname
 import random
 import sys
+import bisect
 
 
 __title__ = 'names'
@@ -37,25 +38,12 @@ def get_name(filename):
     # Do a binary search to pick a name
     selected = random.random() * 90
     names = load_file(filename)
-    max_index = len(names)
-    min_index = 0
-    if min_index == max_index:
-        # Empty file
+    if len(names) == 0:
         return ""
-    while min_index < max_index:
-        index = (min_index + max_index) // 2
-        name, cummulative = names[index]
-        if cummulative < selected:
-            min_index = index
-        else:
-            max_index = index
-        if max_index == min_index + 1:
-            # Once the min_index and max_index are one apart, we need to look at
-            # them directly
-            if names[min_index][1] > selected:
-                return names[min_index][0]
-            return names[max_index][0]
-    return name
+    index = bisect.bisect([cummulative for name, cummulative in names],
+                          selected)
+    return names[index][0]
+
 
 def get_first_name(gender=None):
     if gender is None:

--- a/test_names.py
+++ b/test_names.py
@@ -8,6 +8,7 @@ except:
     from io import StringIO
 from collections import defaultdict
 import names
+from names import bulk as bulk_names
 from names.main import main
 
 
@@ -30,15 +31,16 @@ class patch_stdout(object):
 
 class patch_file:
 
-    def __init__(self, file_dict):
+    def __init__(self, file_dict, names_module=names):
         self.files = file_dict
+        self.names_module = names_module
 
     def __enter__(self):
-        self.old_files = names.FILES
-        names.FILES = self.files
+        self.old_files = self.names_module.FILES
+        self.names_module.FILES = self.files
 
     def __exit__(self, type, value, traceback):
-        names.FILES = self.old_files
+        self.names_module.FILES = self.old_files
 
 test_files = {
     'first:male': full_path('test/male.txt'),
@@ -49,12 +51,15 @@ test_files = {
 
 class NamesTest(unittest.TestCase):
 
+    def setUp(self):
+        self.names = names
+
     def test_get_name(self):
         counts = defaultdict(int)
         rounds = 5000.0
         test_file = full_path('test/file1.txt')
         for i in range(1, int(rounds)):
-            counts[names.get_name(test_file)] += 1
+            counts[self.names.get_name(test_file)] += 1
         self.assertAlmostEqual(counts['Test1'] / rounds, 0.333, delta=0.05)
         self.assertAlmostEqual(counts['Test2'] / rounds, 0.277, delta=0.05)
         self.assertAlmostEqual(counts['Test3'] / rounds, 0.222, delta=0.05)
@@ -64,18 +69,18 @@ class NamesTest(unittest.TestCase):
     def test_random_gender(self):
         counts = defaultdict(int)
         rounds = 5000.0
-        with patch_file(test_files):
+        with patch_file(test_files, self.names):
             for i in range(int(rounds)):
-                names.get_first_name()
-                counts[names.get_first_name()] += 1
+                self.names.get_first_name()
+                counts[self.names.get_first_name()] += 1
         self.assertAlmostEqual(counts['Male'] / rounds, 0.500, delta=0.05)
         self.assertAlmostEqual(counts['Female'] / rounds, 0.500, delta=0.05)
 
     def test_correct_files(self):
-        with patch_file(test_files):
-            self.assertEqual(names.get_first_name(gender='male'), "Male")
-            self.assertEqual(names.get_first_name(gender='female'), "Female")
-            self.assertEqual(names.get_last_name(), "Last")
+        with patch_file(test_files, self.names):
+            self.assertEqual(self.names.get_first_name(gender='male'), "Male")
+            self.assertEqual(self.names.get_first_name(gender='female'), "Female")
+            self.assertEqual(self.names.get_last_name(), "Last")
 
     def test_empty_file(self):
         empty_files = {
@@ -83,14 +88,20 @@ class NamesTest(unittest.TestCase):
             'first:female': full_path('test/empty.txt'),
             'last': full_path('test/empty.txt'),
         }
-        with patch_file(empty_files):
-            self.assertEqual(names.get_first_name(gender='male'), "")
-            self.assertEqual(names.get_first_name(gender='female'), "")
-            self.assertEqual(names.get_last_name(), "")
-    
+        with patch_file(empty_files, self.names):
+            self.assertEqual(self.names.get_first_name(gender='male'), "")
+            self.assertEqual(self.names.get_first_name(gender='female'), "")
+            self.assertEqual(self.names.get_last_name(), "")
+
     def test_only_male_and_female_gender_are_supported(self):
         with self.assertRaises(ValueError):
-            names.get_first_name(gender='other')
+            self.names.get_first_name(gender='other')
+
+
+class BulkNamesTest(NamesTest):
+
+    def setUp(self):
+        self.names = bulk_names
 
 
 class CommandLineTest(unittest.TestCase):

--- a/test_names.py
+++ b/test_names.py
@@ -66,6 +66,20 @@ class NamesTest(unittest.TestCase):
         self.assertAlmostEqual(counts['Test4'] / rounds, 0.166, delta=0.05)
         self.assertEqual(counts['Test5'] / rounds, 0)
 
+    def test_get_fullname(self):
+        counts = defaultdict(int)
+        rounds = 5000.0
+        name_files = {
+            'first:male': full_path('test/male.txt'),
+            'first:female': full_path('test/female.txt'),
+            'last': full_path('test/last.txt'),
+        }
+        with patch_file(name_files, self.names):
+            for i in range(int(rounds)):
+                counts[self.names.get_full_name()] += 1
+            self.assertAlmostEqual(counts['Male Last'] / rounds, 0.500, delta=0.05)
+            self.assertAlmostEqual(counts['Female Last'] / rounds, 0.500, delta=0.05)
+
     def test_random_gender(self):
         counts = defaultdict(int)
         rounds = 5000.0
@@ -73,6 +87,7 @@ class NamesTest(unittest.TestCase):
             for i in range(int(rounds)):
                 self.names.get_first_name()
                 counts[self.names.get_first_name()] += 1
+
         self.assertAlmostEqual(counts['Male'] / rounds, 0.500, delta=0.05)
         self.assertAlmostEqual(counts['Female'] / rounds, 0.500, delta=0.05)
 


### PR DESCRIPTION
I needed to generate several million names for a sample dataset,
and looking up names out of the file every time was very time
consuming.

I left the original logic untouched, as it's the best approach for
a quick, one-off lookup. I've added a separate module, 'names.bulk'
which offers the same interface, but caches the entire file in memory
and picks names with a binary search instead of a scan.

Should resolve: https://github.com/treyhunner/names/issues/3
